### PR TITLE
Restored option to use variable in version field

### DIFF
--- a/vsts-promotepackage-task/task.json
+++ b/vsts-promotepackage-task/task.json
@@ -54,10 +54,10 @@
       "type": "pickList",
       "label": "Package Version",
       "defaultValue": "",
-      "helpMarkDown": "Select the package that you want to promote",
+      "helpMarkDown": "Select the version you want to promote or enter a variable",
       "required": "true",
       "properties": {
-        "EditableOptions": "false"
+        "EditableOptions": "true"
       }
     },
     {
@@ -66,7 +66,7 @@
       "type": "pickList",
       "label": "Release Views",
       "defaultValue": "",
-      "helpMarkDown": "Select the package that you want to promote",
+      "helpMarkDown": "Select the view to which to promote the package",
       "required": "true",
       "properties": {
         "EditableOptions": "false"


### PR DESCRIPTION
I think I understand the reasoning behind removing editability for feed, package and view. But I cannot see any use case for a static version to be promoted every time. Using a variable (and therefore being able to edit that field manually) is a more common scenario from my point of view.
Also see issue #11 