### PR TITLE
Variable values for feed, package, view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 > **10-01-2019**
-> - The feed, package and view to promote can now be specified via variables
+> - The feed, package and view to promote can now be specified via variables (thanks dhuessmann)
 
 > **02-01-2019**
 > - Fixed an issue with editable package version (thanks dhuessmann)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+> **10-01-2019**
+> - The feed, package and view to promote can now be specified via variables
+
 > **02-01-2019**
 > - Fixed an issue with editable package version (thanks dhuessmann)
 

--- a/vsts-promotepackage-task/task.json
+++ b/vsts-promotepackage-task/task.json
@@ -33,7 +33,7 @@
       "helpMarkDown": "Include the selected feed in the generated NuGet.config.",
       "required": "true",
       "properties": {
-        "EditableOptions": "false"
+        "EditableOptions": "true"
       }
     },
     {
@@ -45,7 +45,7 @@
       "helpMarkDown": "Select the package that you want to promote",
       "required": "true",
       "properties": {
-        "EditableOptions": "false"
+        "EditableOptions": "true"
       }
     },
     {
@@ -69,7 +69,7 @@
       "helpMarkDown": "Select the view to which to promote the package",
       "required": "true",
       "properties": {
-        "EditableOptions": "false"
+        "EditableOptions": "true"
       }
     }
   ],

--- a/vsts-promotepackage-task/vsts-promotepackage-task.ps1
+++ b/vsts-promotepackage-task/vsts-promotepackage-task.ps1
@@ -3,7 +3,7 @@ param()
 
 $feedName = Get-VstsInput -Name feed
 $packageId = Get-VstsInput -Name definition
-$packageVersion =Get-VstsInput -Name version
+$packageVersion = Get-VstsInput -Name version
 $releaseView =Get-VstsInput -Name releaseView
 
 $account = ($env:SYSTEM_TEAMFOUNDATIONSERVERURI -replace "https://(.*)\.visualstudio\.com/", '$1').split('.')[0]
@@ -47,33 +47,141 @@ function ValidatePatToken($token)
 	}
 }
 
+function Get-FeedId
+{
+    $ret = ""
+    try
+    {
+        $feedUrl = "$basefeedsurl/$feedName/?api-version=5.0-preview.1"
+        Write-Verbose -Verbose "Trying to retrieve feed information: $feedUrl"
+        $feedResponse = Invoke-RestMethod -Uri $feedUrl -Headers $headers -ContentType "application/json" -Method Get
+        $ret = $feedResponse.id
+    }
+    catch
+    {
+        throw "Unhandled exception while reading feed $feedName"
+    }
+
+    # If the feed id is empty throw an exception (fallback scenario)
+    if ([string]::IsNullOrWhiteSpace($ret))
+    {
+        throw "Feed $feedName could not be found"
+    }
+
+    return $ret
+}
+
+function Get-ViewId($FeedId)
+{
+    $ret = ""
+    try
+    {
+        $viewUrl = "$basefeedsurl/$FeedId/views/$releaseView/?api-version=5.0-preview.1"
+        Write-Verbose -Verbose "Trying to retrieve view information: $viewUrl"
+        $viewResponse = Invoke-RestMethod -Uri $viewUrl -Headers $headers -ContentType "application/json" -Method Get
+        $ret = $viewResponse.id
+    }
+    catch
+    {
+        throw "Unhandled exception while reading view $releaseView"
+    }
+
+    # If the view id is empty throw an exception (fallback scenario)
+    if ([string]::IsNullOrWhiteSpace($ret))
+    {
+        throw "View $releaseView could not be found"
+    }
+
+    return $ret
+}
+
+function Get-PackageInfo($FeedId)
+{
+    $name = "";
+    $protocolType = "";
+    #$ret = ""
+    $isId = $true
+    try
+    {
+        $packageUrl = "$basefeedsurl/$FeedId/packages/$packageId/?api-version=5.0-preview.1"
+        Write-Verbose -Verbose "Trying to retrieve package information: $packageUrl"
+        $packageResponse = Invoke-RestMethod -Uri $packageUrl -Headers $headers -ContentType "application/json" -Method Get
+        $name = $packageResponse.normalizedName
+        $protocolType = $packageResponse.protocolType
+        #$ret = $packageResponse.id
+    }
+    catch [System.Net.WebException]
+    {
+        $isId = $false
+    }
+    catch
+    {
+        throw "Unhandled exception while reading package $packageId by id"
+    }
+
+    # Package not found with id, searching with name
+    if ($isId -eq $false)
+    {
+        try
+        {
+            Write-Verbose -Verbose "Package with id $packageId not found, searching with name"
+            $packagesUrl = "$basefeedsurl/$FeedId/packages?api-version=5.0-preview.1"
+            Write-Verbose -Verbose "Retrieving all packages of requested feed: $packagesUrl"
+            $packagesResponse = Invoke-RestMethod -Uri $packagesUrl -Headers $headers -ContentType "application/json" -Method Get
+            $packages = $packagesResponse.value
+            foreach ($package in $packages)
+            {
+                if ($package.name -eq $packageId)
+                {
+                    $name = $package.normalizedName
+                    $protocolType = $package.protocolType
+                }
+            }
+        }
+        catch
+        {
+            Write-Verbose -Verbose "Failed to retrieve package information by name"
+            throw "Unhandled exception while reading package $packageId by name"
+        }
+    }
+
+    # If the package id is empty throw an exception (fallback scenario)
+    if ([string]::IsNullOrWhiteSpace($name) -or [string]::IsNullOrWhiteSpace($protocolType))
+    {
+        throw "Package $packageId could not be found"
+    }
+
+    return $name, $protocolType
+}
+
 function Set-PackageQuality
 {
-   # First get the name of the package (strange REST API behavior) and the Package Feed Type
-   $packageURL = "$basefeedsurl/$feedName/packages/$packageId/?api-version=2.0-preview"
-   $packResponse = Invoke-RestMethod -Uri $packageURL -Headers $headers -ContentType "application/json" -Method Get 
+    Write-Host "Promoting version $packageVersion of package $packageId from feed $feedName to view $releaseView"
 
-   $feedType = $packResponse.protocolType
-   $packageName = $packResponse.normalizedName
-
+    # Get ids for feed, package and view
+    $feedId = Get-FeedId
+    $viewId = Get-ViewId -FeedId $feedId
+    $packageInfo = Get-PackageInfo -FeedId $feedId
+    $packageName = $packageInfo[0]
+    $feedType = $packageInfo[1]
 
     #API URL is slightly different for npm vs. nuget...
     switch($feedType)
     {
-        "npm" { $releaseViewURL = "$basepackageurl/$feedName/$feedType/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
-        "nuget" { $releaseViewURL = "$basepackageurl/$feedName/$feedType/packages/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
-        default { $releaseViewURL = "$basepackageurl/$feedName/$feedType/packages/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
+        "npm" { $releaseViewURL = "$basepackageurl/$feedId/$feedType/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
+        "nuget" { $releaseViewURL = "$basepackageurl/$feedId/$feedType/packages/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
+        default { $releaseViewURL = "$basepackageurl/$feedId/$feedType/packages/$packageName/versions/$($packageVersion)?api-version=3.0-preview.1" }
     }
-    
+
      $json = @{
         views = @{
             op = "add"
             path = "/views/-"
-            value = "$releaseView"
+            value = "$viewId"
         }
     }
-Write-Host $releaseViewURL
-    $response = Invoke-RestMethod -Uri $releaseViewURL -Headers $headers   -ContentType "application/json" -Method Patch -Body (ConvertTo-Json $json)
+    Write-Host $releaseViewURL
+    $response = Invoke-RestMethod -Uri $releaseViewURL -Headers $headers -ContentType "application/json" -Method Patch -Body (ConvertTo-Json $json)
     return $response
 }
 


### PR DESCRIPTION
- Made feed, package and view fields editable again.
- The current API allows retrieving feed and view information by both the id and name, so the request can be sent with the input values in order to retrieve the id (really just necessary if only the name is specified via variable).
- For packages, if the request with the given input is unsuccessful, the script now iterates over all packages of the given feed and searches for the package with the correct name.